### PR TITLE
Hole macro Interface and Class, LeadIn management 

### DIFF
--- a/3DCanvasApp/3DCanvasApp.csproj
+++ b/3DCanvasApp/3DCanvasApp.csproj
@@ -92,6 +92,7 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/3DCanvasApp/Window1.xaml.cs
+++ b/3DCanvasApp/Window1.xaml.cs
@@ -87,11 +87,19 @@ namespace Canvas3DViewer
                         else if (item.EntityType == EEntityType.Arc)
                         {
                             DrawArc(item as ArcMove);
+                        }                        
+                        else if (item.EntityType == EEntityType.Hole)
+                        {
+                            var hole = item as HoleMoves;
+                            DrawLine(hole.LeadIn as LinearMove);
+                            DrawArc(hole.Circle as ArcMove);
+                            
                         }
                         else if (item.EntityType == EEntityType.Slot)
                         {
                             var slot = item as SlotMove;
 
+                            DrawLine(slot.LeadIn as LinearMove);
                             DrawArc(slot.Arc1 as ArcMove);
                             DrawLine(slot.Line1 as LinearMove);
                             DrawArc(slot.Arc2 as ArcMove);
@@ -100,7 +108,7 @@ namespace Canvas3DViewer
                         else if (item.EntityType == EEntityType.Keyhole)
                         {
                             var keyhole = item as KeyholeMoves;
-
+                            DrawLine(keyhole.LeadIn as LinearMove);
                             DrawArc(keyhole.Arc1 as ArcMove);
                             DrawLine(keyhole.Line1 as LinearMove);
                             DrawArc(keyhole.Arc2 as ArcMove);
@@ -110,6 +118,7 @@ namespace Canvas3DViewer
                         {
                             var poly = item as PolyMoves;
 
+                            DrawLine(poly.LeadIn as LinearMove);
                             foreach (var l in poly.Lines)
                             {
                                 DrawLine(l as LinearMove);
@@ -118,7 +127,7 @@ namespace Canvas3DViewer
                         else if (item.EntityType == EEntityType.Rect)
                         {
                             var rect = item as RectMoves;
-
+                            DrawLine(rect.LeadIn as LinearMove);
                             foreach (var l in rect.Lines)
                             {
                                 DrawLine(l as LinearMove);

--- a/ParserLib/Entities/Parsers/ParseIso.cs
+++ b/ParserLib/Entities/Parsers/ParseIso.cs
@@ -477,10 +477,6 @@ namespace ParserLib.Services.Parsers
             BuildMove(ref entity, regexMatches, programContext);
             e.EndPoint = Create3DPoint(programContext, programContext.ReferenceMove.EndPoint, (entity as IEntity).EndPoint, programContext.IsIncremental ? programContext.LastEntity.EndPoint : new Point3D(0, 0, 0));
             GeoHelper.Add2DMoveProperties(ref e, isClockwise);
-            Console.WriteLine(e.ToString());
-            Console.WriteLine(e.CenterPoint.ToString());
-
-
             return e;
         }
 

--- a/ParserLib/Entities/Parsers/ParseIso.cs
+++ b/ParserLib/Entities/Parsers/ParseIso.cs
@@ -306,13 +306,15 @@ namespace ParserLib.Services.Parsers
                 baseEntity.Is2DProgram = programContext.Is2DProgram;
 
                 if (baseEntity.EntityType == EEntityType.Rect)
-                    programContext.LastHeadPosition = (baseEntity as RectMoves).Lines.Last().EndPoint;
+                    programContext.LastHeadPosition = (baseEntity as RectMoves).LeadIn.EndPoint;
                 else if (baseEntity.EntityType == EEntityType.Slot)
-                    programContext.LastHeadPosition = (baseEntity as SlotMove).Line2.EndPoint;
+                    programContext.LastHeadPosition = (baseEntity as SlotMove).LeadIn.EndPoint;
                 else if (baseEntity.EntityType == EEntityType.Poly)
-                    programContext.LastHeadPosition = (baseEntity as PolyMoves).Lines.Last().EndPoint;
+                    programContext.LastHeadPosition = (baseEntity as PolyMoves).LeadIn.EndPoint;
                 else if (baseEntity.EntityType == EEntityType.Keyhole)
-                    programContext.LastHeadPosition = (baseEntity as KeyholeMoves).Line2.EndPoint;
+                    programContext.LastHeadPosition = (baseEntity as KeyholeMoves).LeadIn.EndPoint;
+                else if (baseEntity.EntityType == EEntityType.Hole)
+                    programContext.LastHeadPosition = (baseEntity as HoleMoves).LeadIn.EndPoint;
                 else
                     programContext.LastHeadPosition = (baseEntity as Entity).EndPoint;
 
@@ -518,15 +520,15 @@ namespace ParserLib.Services.Parsers
         {
             if (p3 != null)
             {
-                return new Point3D((p1.X + p2.X + p3.X), (p1.Y + p2.Y + p3.Y), (p1.Z + p2.Z + p3.Z));// programContext.Is2DProgram ? 0 : (p1.Z + p2.Z + p3.Z));
+                return new Point3D((p1.X + p2.X + p3.X), (p1.Y + p2.Y + p3.Y), (p1.Z + p2.Z + p3.Z));
             }
             else if (p2 != null)
             {
-                return new Point3D((p1.X + p2.X), (p1.Y + p2.Y), programContext.Is2DProgram ? 0 : (p1.Z + p2.Z));
+                return new Point3D((p1.X + p2.X), (p1.Y + p2.Y),  (p1.Z + p2.Z));
             }
             else if (p1 != null)
             {
-                return new Point3D((p1.X), (p1.Y), programContext.Is2DProgram ? 0 : p1.Z);
+                return new Point3D((p1.X), (p1.Y), p1.Z);
             }
 
             return new Point3D(0, 0, 0);
@@ -594,20 +596,47 @@ namespace ParserLib.Services.Parsers
 
                 var radius = Converter(macroParFounded[6].Value);
 
-                entity = new ArcMove
-                {
-                    IsStroked = true,
-                    IsLargeArc = true,
+                //entity = new ArcMove
+                //{
+                //    IsStroked = true,
+                //    IsLargeArc = true,
+                //    SourceLine = programContext.SourceLine,
+                //    IsBeamOn = programContext.IsBeamOn,
+                //    LineColor = programContext.ContourLineType,
+                //    OriginalLine = line,
+                //    Radius = Math.Abs(radius),//Aggiunto math.abs perchè... Se si vedessero comportamenti strani, verificare che la direzione della normale segua la regola della mano sinistra rispetto al verso di percorrenza dell'arco.
+                //    CenterPoint = Create3DPoint(programContext, programContext.ReferenceMove.EndPoint, pC),
+                //    NormalPoint = Create3DPoint(programContext, programContext.ReferenceMove.EndPoint, pN),
+                //};
+                entity = new HoleMoves
+                {   
                     SourceLine = programContext.SourceLine,
                     IsBeamOn = programContext.IsBeamOn,
                     LineColor = programContext.ContourLineType,
                     OriginalLine = line,
-                    Radius = Math.Abs(radius),//Aggiunto math.abs perchè... Se si vedessero comportamenti strani, verificare che la direzione della normale segua la regola della mano sinistra rispetto al verso di percorrenza dell'arco.
-                    CenterPoint = Create3DPoint(programContext, programContext.ReferenceMove.EndPoint, pC),
-                    NormalPoint = Create3DPoint(programContext, programContext.ReferenceMove.EndPoint, pN),
+                    Radius= radius,
+                    Circle = new ArcMove
+                    {
+                        SourceLine = programContext.SourceLine,
+                        IsBeamOn = programContext.IsBeamOn,
+                        LineColor = programContext.ContourLineType,
+                        OriginalLine = line,
+                        IsStroked = true,
+                        IsLargeArc = false,
+                        Radius = Math.Abs(radius),//Aggiunto math.abs perchè... Se si vedessero comportamenti strani, verificare che la direzione della normale segua la regola della mano sinistra rispetto al verso di percorrenza dell'arco.
+                        CenterPoint = Create3DPoint(programContext, programContext.ReferenceMove.EndPoint, pC),
+                        NormalPoint = Create3DPoint(programContext, programContext.ReferenceMove.EndPoint, pN),
+                    },
+                    LeadIn = new LinearMove {
+                        SourceLine = programContext.SourceLine,
+                        OriginalLine = line,
+                        StartPoint= programContext.LastHeadPosition,
+                    }
+                    
+
                 };
 
-                var holeMacro = entity as ArcMove;
+                var holeMacro = entity as HoleMoves;
                 GeoHelper.GetMoveFromMacroHole(ref holeMacro);
             }
             else if (line.StartsWith("$(SLOT)"))
@@ -674,7 +703,16 @@ namespace ParserLib.Services.Parsers
                         IsBeamOn = programContext.IsBeamOn,
                         LineColor = programContext.ContourLineType,
                         OriginalLine = line,
+                    },
+                    LeadIn = new LinearMove()
+                    {
+                        SourceLine = programContext.SourceLine,
+                        OriginalLine = line,
+                        StartPoint = programContext.LastHeadPosition,
+
                     }
+
+                    
                 };
 
                 var slotMove = entity as SlotMove;
@@ -751,6 +789,13 @@ namespace ParserLib.Services.Parsers
                         IsBeamOn = programContext.IsBeamOn,
                         LineColor = programContext.ContourLineType,
                         OriginalLine = line,
+                    },
+                    LeadIn = new LinearMove()
+                    {
+                        SourceLine = programContext.SourceLine,
+                        OriginalLine = line,
+                        StartPoint = programContext.LastHeadPosition,
+
                     }
 
                 };
@@ -795,7 +840,14 @@ namespace ParserLib.Services.Parsers
                     Radius = radius,
                     VertexPoint = vertexPoint,
                     NormalPoint = normalPoint,
-                    CenterPoint = centerPoint
+                    CenterPoint = centerPoint,
+                    LeadIn = new LinearMove()
+                    {
+                        SourceLine = programContext.SourceLine,
+                        OriginalLine = line,
+                        StartPoint = programContext.LastHeadPosition,
+
+                    }
                 };
 
                 var polyMove = entity as PolyMoves;
@@ -828,8 +880,16 @@ namespace ParserLib.Services.Parsers
                     OriginalLine = line,
                     SidePoint = sidePoint,
                     VertexPoint = vertexPoint,
-                    CenterPoint = centerPoint
+                    CenterPoint = centerPoint,
+                    LeadIn = new LinearMove()
+                    {
+                        SourceLine = programContext.SourceLine,
+                        OriginalLine = line,
+                        StartPoint = programContext.LastHeadPosition,
+
+                    }
                 };
+
 
                 var rectMove = entity as RectMoves;
                 GeoHelper.GetMovesFromMacroRect(ref rectMove);

--- a/ParserLib/Entities/Parsers/ParseMpf.cs
+++ b/ParserLib/Entities/Parsers/ParseMpf.cs
@@ -492,7 +492,7 @@ namespace ParserLib.Services.Parsers
                     };
 
                     var holeMacro = entity as ArcMove;
-                    GeoHelper.GetMoveFromMacroHole(ref holeMacro);
+                    //GeoHelper.GetMoveFromMacroHole(ref holeMacro);
                     break;
                 case "P_SLOT":
                     macroParFounded = MacroParsRegex.Matches(line);

--- a/ParserLib/Helpers/MathHelpers.cs
+++ b/ParserLib/Helpers/MathHelpers.cs
@@ -9,8 +9,8 @@ namespace ParserLib.Helpers
 {
     internal class MathHelpers
     {
-        ///<summary> Rotates the first vector around the pivot vector by alpha RADIANTS, Returns the rotated vector </summary> 
-        public static Vector3D Rotate_Rodriguez(Vector3D vectorToRotate, Vector3D pivotVector, double alpha)
+        ///<summary>  Rotates the first vector around the pivot vector by alpha RADIANTS, Returns the rotated vector </summary> 
+        public static Vector3D RotateAround(Vector3D vectorToRotate, Vector3D pivotVector, double alpha)
         {
             Vector3D rotatedVector = vectorToRotate * Math.Cos(alpha) + Vector3D.CrossProduct(pivotVector, vectorToRotate) * Math.Sin(alpha) + pivotVector * (Vector3D.DotProduct(pivotVector, vectorToRotate) * (1 - Math.Cos(alpha)));
             return rotatedVector;
@@ -26,7 +26,51 @@ namespace ParserLib.Helpers
             if  (test < 0.0) return true; else return false;
 
         }
-      
+        ///<summary> Returns the closest point to the givenPoint from a list of points </summary> 
+        public static Point3D GetClosestPoint(Point3D givenPoint, List<Point3D> points)
+        {
+            Point3D closestPoint = points[0];
+            foreach (Point3D point in points.Skip(1)) { 
+                if (Point3D.Subtract(givenPoint,point).Length < Point3D.Subtract(givenPoint, closestPoint).Length)
+                {
+                    closestPoint = point;
+                }
+            }
+            return closestPoint;
+
+        }
+        ///<summary> Returns the closest point to the givenPoint from a list of points </summary> 
+        public static Point3D GetClosestPoint(Point3D givenPoint, Point3D[] points)
+        {
+            Point3D closestPoint = points[0];
+            foreach (Point3D point in points.Skip(1))
+            {
+                if (Point3D.Subtract(givenPoint, point).Length < Point3D.Subtract(givenPoint, closestPoint).Length)
+                {
+                    closestPoint = point;
+                }
+            }
+            return closestPoint;
+
+        }
+
+        ///<summary> Returns the closest point to the givenPoint from a list of points </summary> 
+        public static (Point3D point,int index) GetClosestPointID(Point3D givenPoint, Point3D[] points)
+        {
+            Point3D closestPoint = points[0];
+            int index = 0;
+            for (int i = 0; i < points.Length; i++)
+            {
+                if (Point3D.Subtract(givenPoint, points[i]).Length < Point3D.Subtract(givenPoint, closestPoint).Length)
+                {
+                    closestPoint = points[i];
+                    index = i;
+                }
+            }
+            return (point:closestPoint,index:index);
+
+        }
+
 
 
     }

--- a/ParserLib/Helpers/TechnoHelper.cs
+++ b/ParserLib/Helpers/TechnoHelper.cs
@@ -23,7 +23,8 @@
             Rapid,
             Poly,
             Rect,
-            Keyhole
+            Keyhole,
+            Hole
         }
     }
 }

--- a/ParserLib/Interfaces/IHole.cs
+++ b/ParserLib/Interfaces/IHole.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ParserLib.Models;
+
+namespace ParserLib.Interfaces
+{
+    public interface IHole : IEntity
+    {
+
+        CircularEntity Circle { get; set; } 
+        Entity LeadIn { get; set; }
+
+        double Radius { get; set; }
+
+
+        
+        
+    }
+}

--- a/ParserLib/Interfaces/IKeyhole.cs
+++ b/ParserLib/Interfaces/IKeyhole.cs
@@ -13,5 +13,7 @@ namespace ParserLib.Interfaces
         CircularEntity Arc2 { get; set; }
         Entity Line1 { get; set; }
         Entity Line2 { get; set; }
+
+        Entity LeadIn { get; set; }
     }
 }

--- a/ParserLib/Interfaces/IPoly.cs
+++ b/ParserLib/Interfaces/IPoly.cs
@@ -11,5 +11,7 @@ namespace ParserLib.Interfaces
         Point3D CenterPoint { get; set; }
         Point3D VertexPoint { get; set; }
         List<Entity> Lines { get; set; }
+
+        Entity LeadIn { get; set; }
     }
 }

--- a/ParserLib/Interfaces/IRect.cs
+++ b/ParserLib/Interfaces/IRect.cs
@@ -10,5 +10,7 @@ namespace ParserLib.Interfaces
         Point3D CenterPoint { get; set; }
         Point3D VertexPoint { get; set; }
         List<LinearMove> Lines { get; set; }
+
+        Entity LeadIn { get; set; }
     }
 }

--- a/ParserLib/Interfaces/ISlot.cs
+++ b/ParserLib/Interfaces/ISlot.cs
@@ -8,5 +8,7 @@ namespace ParserLib.Interfaces
         CircularEntity Arc2 { get; set; }
         Entity Line1 { get; set; }
         Entity Line2 { get; set; }
+
+        Entity LeadIn { get; set; }
     }
 }

--- a/ParserLib/Models/HoleMoves.cs
+++ b/ParserLib/Models/HoleMoves.cs
@@ -1,0 +1,56 @@
+﻿using ParserLib.Helpers;
+using ParserLib.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Media3D;
+using System.Windows.Shapes;
+
+namespace ParserLib.Models
+{
+    public class HoleMoves : Entity, IHole
+    {
+        public CircularEntity Circle { get; set; }
+        public Entity LeadIn { get; set; }
+        public double Radius { get; set; }
+        public override TechnoHelper.EEntityType EntityType => TechnoHelper.EEntityType.Hole;
+
+
+        public override Tuple<double, double, double, double> BoundingBox
+        {
+            get
+            {
+                double xMin = double.PositiveInfinity;
+                double xMax = double.NegativeInfinity;
+                double yMin = double.PositiveInfinity;
+                double yMax = double.NegativeInfinity;
+
+                xMin = Math.Min(Circle.GeometryPath.Bounds.Left, xMin);
+                xMin = Math.Max(LeadIn.GeometryPath.Bounds.Left, xMin);
+
+                xMax = Math.Min(Circle.GeometryPath.Bounds.Right, xMax);
+                xMax = Math.Max(LeadIn.GeometryPath.Bounds.Right, xMax);
+
+                yMin = Math.Min(Circle.GeometryPath.Bounds.Bottom, yMin);
+                yMin = Math.Max(LeadIn.GeometryPath.Bounds.Bottom, yMin);
+
+                yMax = Math.Min(Circle.GeometryPath.Bounds.Top, yMax);
+                yMax = Math.Max(LeadIn.GeometryPath.Bounds.Top, yMax);
+                return new Tuple<double, double, double, double>(xMin, xMax, yMin, yMax);
+            }
+        }
+
+        public override void Render(Matrix3D U, Matrix3D Un, bool isRot, double Zradius)
+        {
+            if (Circle != null)
+                Circle.Render(U, Un, isRot, Zradius);
+            if (LeadIn != null)
+                LeadIn.Render(U, Un, isRot, Zradius);
+        }
+    }
+
+
+}

--- a/ParserLib/Models/KeyholeMoves.cs
+++ b/ParserLib/Models/KeyholeMoves.cs
@@ -16,6 +16,7 @@ namespace ParserLib.Models
         public CircularEntity Arc1 {get; set; }
         public CircularEntity Arc2 {get; set; }
 
+        public Entity LeadIn { get; set; }
         public Entity Line1 {get; set; }
         public Entity Line2 {get; set; }
 
@@ -59,6 +60,8 @@ namespace ParserLib.Models
                 Line1.Render(U, Un, isRot, Zradius);
             if (Line2 != null)
                 Line2.Render(U, Un, isRot, Zradius);
+            if (LeadIn != null)
+                LeadIn.Render(U, Un, isRot, Zradius);
             //throw new NotImplementedException();
         }
     }

--- a/ParserLib/Models/PolyMoves.cs
+++ b/ParserLib/Models/PolyMoves.cs
@@ -14,6 +14,8 @@ namespace ParserLib.Models
 
         public List<Entity> Lines { get; set; }
 
+        public Entity LeadIn { get; set; }
+
         public override TechnoHelper.EEntityType EntityType => TechnoHelper.EEntityType.Poly;
 
         public override Tuple<double, double, double, double> BoundingBox
@@ -38,6 +40,9 @@ namespace ParserLib.Models
 
         public override void Render(Matrix3D U, Matrix3D Un, bool isRot, double Zradius)
         {
+
+            if (LeadIn != null)
+                LeadIn.Render(U, Un, isRot, Zradius);
             foreach (var item in Lines)
             {
                 item.Render(U, Un, isRot, Zradius);

--- a/ParserLib/Models/ProgramContext.cs
+++ b/ParserLib/Models/ProgramContext.cs
@@ -81,6 +81,13 @@ namespace ParserLib.Models
                     CalculateMinMaxFromBaseEntity(keyHole.Arc2);
                     CalculateMinMaxFromBaseEntity(keyHole.Line1);
                     CalculateMinMaxFromBaseEntity(keyHole.Line2);
+                }                
+                else if (LastEntity.EntityType == EEntityType.Hole)
+                {
+                    var hole = LastEntity as IHole;
+
+                    CalculateMinMaxFromBaseEntity(hole.Circle);
+
                 }
                 else
                 {

--- a/ParserLib/Models/RectMoves.cs
+++ b/ParserLib/Models/RectMoves.cs
@@ -13,10 +13,14 @@ namespace ParserLib.Models
         public Point3D VertexPoint { get; set; }
         public List<LinearMove> Lines { get; set; }
 
+        public Entity LeadIn { get; set; }
+
         public override TechnoHelper.EEntityType EntityType => TechnoHelper.EEntityType.Rect;
 
         public override void Render(Matrix3D U, Matrix3D Un, bool isRot, double Zradius)
         {
+            if (LeadIn != null)
+                LeadIn.Render(U, Un, isRot, Zradius);
             foreach (var item in Lines)
             {
                 item.Render(U, Un, isRot, Zradius);

--- a/ParserLib/Models/SlotMove.cs
+++ b/ParserLib/Models/SlotMove.cs
@@ -12,6 +12,9 @@ namespace ParserLib.Models
         public Entity Line1 { get; set; }
         public Entity Line2 { get; set; }
 
+        public Entity LeadIn { get; set; }
+
+
         public override Tuple<double, double, double, double> BoundingBox
         {
             get
@@ -46,6 +49,8 @@ namespace ParserLib.Models
 
         public override TechnoHelper.EEntityType EntityType => TechnoHelper.EEntityType.Slot;
 
+        
+
         public override void Render(Matrix3D U, Matrix3D Un, bool isRot, double Zradius)
         {
             if (Arc1 != null)
@@ -55,7 +60,9 @@ namespace ParserLib.Models
             if (Line1 != null)
                 Line1.Render(U, Un, isRot, Zradius);
             if (Line2 != null)
-                Line2.Render(U, Un, isRot, Zradius);
+                Line2.Render(U, Un, isRot, Zradius); 
+            if (LeadIn != null)
+                LeadIn.Render(U, Un, isRot, Zradius);
         }
     }
 }

--- a/ParserLib/ParserLib.csproj
+++ b/ParserLib/ParserLib.csproj
@@ -15,5 +15,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Globals\Globals.cs" />
+    <Compile Remove="Interfaces\Interface1.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hole macro is now a interface of its own , has a property Circle that implements the previous ArcMove logic.

All the Macros have a new LinearMove LeadIn, calculated inside the GeoHelper methods.
Macros last point is coherent with the lead in

MathHelpers has new methods to get the closest point against a list of points